### PR TITLE
Add example config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-secrets
+secrets/*.json
 npm-debug.log
 filelog-debug.log
 filelog-error.log

--- a/secrets/database.json.example
+++ b/secrets/database.json.example
@@ -1,0 +1,5 @@
+{
+  "username": "XXXX",
+  "password": "XXXX",
+  "address": "host:port"
+}

--- a/secrets/oauth.json.example
+++ b/secrets/oauth.json.example
@@ -1,0 +1,14 @@
+{
+  "iD": {
+    "consumerKey": "ID_KEY",
+    "consumerSecret": "ID_SECRET"
+  },
+  "arc2places": {
+    "consumerKey": "ARC_KEY",
+    "consumerSecret": "ARC_SECRET"
+  },
+  "josm": {
+    "consumerKey": "JOSM_KEY",
+    "consumerSecret": "JOSM_SECRET"
+  }
+}


### PR DESCRIPTION
Having these examples make it easier to redeploy on a new server without having to read the code to figure out the config file structure.  It also servers as a good place to track changes to the secrets file structure.
